### PR TITLE
Fix propagation of the gameobject messages to the nested objects

### DIFF
--- a/src/project/game_object.cpp
+++ b/src/project/game_object.cpp
@@ -115,6 +115,12 @@ void game_object::init()
         return;
     }
 
+    visit_children([](auto& c) -> bool
+    {
+        c->init();
+        return true;
+    });
+
     visit_components(
         [](auto& c) -> bool
     {
@@ -129,6 +135,12 @@ void game_object::update()
     {
         return;
     }
+
+    visit_children([](auto& c) -> bool
+    {
+        c->update();
+        return true;
+    });
 
     visit_components(
         [](auto& c) -> bool
@@ -145,6 +157,12 @@ void game_object::draw_gizmos()
         return;
     }
 
+    visit_children([](auto& c) -> bool
+    {
+        c->draw_gizmos();
+        return true;
+    });
+
     visit_components(
         [](auto& c) -> bool
     {
@@ -159,6 +177,12 @@ void game_object::deinit()
     {
         return;
     }
+
+    visit_children([](auto& c) -> bool
+    {
+        c->deinit();
+        return true;
+    });
 
     visit_components(
         [](auto& c) -> bool

--- a/unittest/project_ut/CMakeLists.txt
+++ b/unittest/project_ut/CMakeLists.txt
@@ -2,8 +2,8 @@ enable_testing()
 
 add_executable(${PROJECT}_project_ut game_object.cpp component_management.cpp)
 
-target_link_libraries(${PROJECT}_project_ut GTest::gtest_main
-                      ${PROJECT}::project)
+target_link_libraries(${PROJECT}_project_ut GTest::gtest_main GTest::gmock
+    ${PROJECT}::project)
 
 target_precompile_headers(${PROJECT}_project_ut REUSE_FROM ${PROJECT}::project)
 

--- a/unittest/project_ut/component_management.cpp
+++ b/unittest/project_ut/component_management.cpp
@@ -1,5 +1,7 @@
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include "project/component_interface/component_registry.hpp"
 #include "project/components/mesh_filter.hpp"
 #include "project/components/mesh_renderer.hpp"
 #include "project/game_object.hpp"
@@ -35,10 +37,51 @@ TEST(ProjectComponentManagement, add_component_same_as_get_component_2)
 
     auto obj = game_object::create();
     std::shared_ptr<graphics::mesh> m = std::shared_ptr<graphics::mesh>(
-        reinterpret_cast<graphics::mesh*>(0xff00ff00ff00ff00), [](auto) {});
+        reinterpret_cast<graphics::mesh*>(0xff00ff00ff00ff00), [](auto) { });
     obj->add<components::mesh_filter>().set_mesh(m);
     auto& mf = obj->get<components::mesh_filter>();
 
     EXPECT_EQ(mf.get_mesh().get(),
               reinterpret_cast<graphics::mesh*>(0xff00ff00ff00ff00));
+}
+
+class test_component : public component
+{
+public:
+    using base = component;
+
+    test_component(game_object& obj)
+        : component(type_name, obj)
+    {
+    }
+
+    MOCK_METHOD(void, on_init, (), (override));
+    MOCK_METHOD(void, on_update, (), (override));
+    MOCK_METHOD(void, on_deinit, (), (override));
+
+    static constexpr std::string_view type_name = "test_component";
+};
+
+TEST(ProjectComponentManagement, nested_object_component_update)
+{
+    project_manager::initialize();
+    component_registry::register_component<test_component>("test_component");
+
+    auto obj = game_object::create();
+
+    auto nested = game_object::create();
+    obj->add_child(nested);
+
+    auto& tc = nested->add<test_component>();
+
+    EXPECT_CALL(tc, on_init()).Times(1);
+
+    EXPECT_CALL(tc, on_update()).Times(5);
+
+    obj->init();
+
+    for (int i = 0; i < 5; i++)
+    {
+        obj->update();
+    }
 }


### PR DESCRIPTION
Forward the following messages to the nested objects of the `game_object`
- `on_init`
- `on_update`
- `on_draw_gizmos`
- `on deinit`

Also, adds a unit test to cover these nested propagation.